### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ class App extends React.Component<{
     );
   }
   increment = (amt: number) => { // like this
-    this.setState({
-      count: this.state.count + amt
-    });
+    this.setState(state => ({
+      count: state.count + amt
+    }));
   }
 }
 ```
@@ -422,9 +422,9 @@ class App extends React.Component<{}, {
     );
   }
   increment = (amt: number) => {
-    this.setState({
-      count: this.state.count + amt
-    });
+    this.setState(state => ({
+      count: (state.count || 0) + amt
+    }));
   }
 }
 ```


### PR DESCRIPTION
Using this.state in setState is discouraged due to potential timing issues.

Might want to rethink the union type example, addition to null would give a type error and the fix looks unwieldy.