### PR TITLE
Update defaultProps suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ we chose to propose this way of implementing them:
 
 ```ts
 interface IMyComponentProps {
-  firstProp: string;
+  firstProp?: string;
   secondProp: IPerson[];
 }
 
-export class MyComponent extends React.Component<IMyComponentProps, {}> {
-  static defaultProps: Partial<IMyComponentProps> = {
+export class MyComponent extends React.Component<IMyComponentProps> {
+  public static defaultProps: Partial<IMyComponentProps> = {
     firstProp: "default",
   };
 }


### PR DESCRIPTION
1. firstProp needs to be optional in the props Interface in order to get no errors when using MyComponent without it
2. the static defaultProps has a public modifier on the react typings, so it's good practice to also do this in extended classes.
3. state generic can and probably should be omitted when empty (readability)