### PR TITLE
Adding string literals example to basic prop types

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ type AppProps = {
   disabled: boolean,
   // array of a type!
   names: string[], 
+  // string literals to specify exact string values
+  status: 'waiting' | 'success',
   // any object as long as you dont use its properties (not common)
   obj: object, 
   obj2: {}, // same


### PR DESCRIPTION
Thought it would be useful to have it there since it's very common. I know it's explained further in unions and enums with string values but for me, I didn't notice them first and needed to google it :smile