### PR TITLE
add HOC cheatsheet

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,9 +1,10 @@
 # Advanced Cheatsheet
 
 **This Advanced Cheatsheet** helps show and explain advanced usage of generic types for people writing reusable type utilities/functions/render prop/higher order components and TS+React **libraries**.
-  - It also has miscellaneous tips and tricks for pro users. 
-  - Advice for contributing to DefinitelyTyped
-  - The goal is to take *full advantage* of TypeScript.
+
+- It also has miscellaneous tips and tricks for pro users.
+- Advice for contributing to DefinitelyTyped
+- The goal is to take _full advantage_ of TypeScript.
 
 ---
 
@@ -15,31 +16,31 @@
 
 - [Section 0: Utility Types](#section-0-utility-types)
 - [Section 1: Reusable Components/Type Utilities](#section-1-reusable-componentstype-utilities)
-  * [Higher Order Components](#higher-order-components-hocs)
-  * [Render Props](#render-props)
-  * [`as` props (passing a component to be rendered)](#as-props-passing-a-component-to-be-rendered)
-  * [Types for Conditional Rendering](#types-for-conditional-rendering)
-  * [Props: One or the Other but not Both](#props-one-or-the-other-but-not-both)
-  * [Props: Must Pass Both](#props-one-or-the-other-but-not-both)
-  * [Omit attribute from a type](#omit-attribute-from-a-type)
-  * [Type Zoo](#type-zoo)
-  * [Extracting Prop Types of a Component](#extracting-prop-types-of-a-component)
-  * [Third Party Libraries](#third-party-libraries)
+  - [Higher Order Components](#higher-order-components-hocs)
+  - [Render Props](#render-props)
+  - [`as` props (passing a component to be rendered)](#as-props-passing-a-component-to-be-rendered)
+  - [Types for Conditional Rendering](#types-for-conditional-rendering)
+  - [Props: One or the Other but not Both](#props-one-or-the-other-but-not-both)
+  - [Props: Must Pass Both](#props-one-or-the-other-but-not-both)
+  - [Omit attribute from a type](#omit-attribute-from-a-type)
+  - [Type Zoo](#type-zoo)
+  - [Extracting Prop Types of a Component](#extracting-prop-types-of-a-component)
+  - [Third Party Libraries](#third-party-libraries)
 - [Section 2: Useful Patterns by TypeScript Version](#section-2-useful-patterns-by-typescript-version)
-  * [TypeScript 2.9](#typescript-29)
-  * [TypeScript 3.0](#typescript-30)
-  * [TypeScript 3.1](#typescript-31)
-  * [TypeScript 3.2](#typescript-32)
+  - [TypeScript 2.9](#typescript-29)
+  - [TypeScript 3.0](#typescript-30)
+  - [TypeScript 3.1](#typescript-31)
+  - [TypeScript 3.2](#typescript-32)
 - [Section 3: Misc. Concerns](#section-3-misc-concerns)
-  * [Writing TypeScript Libraries instead of Apps](#writing-typescript-libraries-instead-of-apps)
-  * [Commenting Components](#commenting-components)
-  * [Design System Development](#design-system-development)
-  * [Migrating from Flow](#migrating-from-flow)
-  * [Prettier + TSLint](#prettier--tslint)
-  * [ESLint + TSLint](#eslint--tslint)
-  * [Working with Non-TypeScript Libraries (writing your own index.d.ts)](#working-with-non-typescript-libraries-writing-your-own-indexdts)
+  - [Writing TypeScript Libraries instead of Apps](#writing-typescript-libraries-instead-of-apps)
+  - [Commenting Components](#commenting-components)
+  - [Design System Development](#design-system-development)
+  - [Migrating from Flow](#migrating-from-flow)
+  - [Prettier + TSLint](#prettier--tslint)
+  - [ESLint + TSLint](#eslint--tslint)
+  - [Working with Non-TypeScript Libraries (writing your own index.d.ts)](#working-with-non-typescript-libraries-writing-your-own-indexdts)
 - [Section 4: @types/react and @types/react-dom APIs](#section-4-typesreact-and-typesreact-dom-apis)
-</details>
+  </details>
 
 # Section 0: Utility Types
 
@@ -69,7 +70,10 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 You can also supply string literals to omit:
 
 ```ts
-type SettingsPageProps = Omit<ServerConfig, 'immutableSetting1' | 'invisibleSetting2'>
+type SettingsPageProps = Omit<
+  ServerConfig,
+  'immutableSetting1' | 'invisibleSetting2'
+>;
 ```
 
 </details>
@@ -102,8 +106,8 @@ type Nullable<T> = T | null
 type Maybe<T> = T | undefined
 ```
 
-  Your choice of `null` or `undefined` depends on your approach toward missing values. Some folks feel strongly one way or the other.
-  
+Your choice of `null` or `undefined` depends on your approach toward missing values. Some folks feel strongly one way or the other.
+
 </details>
 <details>
   <summary>
@@ -117,9 +121,15 @@ type Maybe<T> = T | undefined
 type Dictionary<T> = { [key: string]: T }
 ```
 
- `[key: string]` is a very handy trick in general.  You can also modify dictionary fields with [Readonly](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) or make them optional or Omit them, etc.
- 
+`[key: string]` is a very handy trick in general. You can also modify dictionary fields with [Readonly](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) or make them optional or Omit them, etc.
+
 </details>
+
+There also exist helper type libraries:
+
+- [utility-types](https://github.com/piotrwitek/utility-types)
+- [type-zoo](https://github.com/pelotom/type-zoo)
+- [typesafe-actions](https://github.com/piotrwitek/typesafe-actions)
 
 [Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new). We respect the fact that naming and selection of examples here is arbitrary as the possible space is infinite.
 
@@ -142,7 +152,6 @@ interface WithThemeProps {
 The goal is to have the props available on the interface for the component, but subtracted out for the consumers of the component when wrapped in the HoC.
 
 ```ts
-
 interface Props extends WithThemeProps {
   children: ReactNode;
 }
@@ -174,12 +183,17 @@ Now when consuming the component you can omit the `primaryColor` prop or overrid
 The actual HoC.
 
 ```ts
-export function withTheme<T extends WithThemeProps = WithThemeProps>(WrappedComponent: React.ComponentType<T>) {
+export function withTheme<T extends WithThemeProps = WithThemeProps>(
+  WrappedComponent: React.ComponentType<T>
+) {
   // Try to create a nice displayName for React Dev Tools.
-  const displayName = WrappedComponent.displayName || WrappedComponent.name || "Component";
+  const displayName =
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
   // Creating the inner component. The calculated Props type here is the where the magic happens.
-  return class ComponentWithTheme extends React.Component<Optionalize<T, WithThemeProps>> {
+  return class ComponentWithTheme extends React.Component<
+    Optionalize<T, WithThemeProps>
+  > {
     public static displayName = `withPages(${displayName})`;
 
     public render() {
@@ -189,23 +203,24 @@ export function withTheme<T extends WithThemeProps = WithThemeProps>(WrappedComp
       // this.props comes afterwards so the can override the default ones.
       return <WrappedComponent {...themeProps} {...this.props as T} />;
     }
-  }
+  };
 }
 ```
 
 Note that the `{...this.props as T}` assertion is needed because of a current bug in TS 3.2 https://github.com/Microsoft/TypeScript/issues/28938#issuecomment-450636046
 
 Here is a more advanced example of a dynamic higher order component that bases some of its parameters on the props of the component being passed in:
+
 ```ts
 // inject static values to a component so that they're always provided
 export function inject<TProps, TInjectedKeys extends keyof TProps>(
   Component: React.JSXElementConstructor<TProps>,
   injector: Pick<TProps, TInjectedKeys>
- ) {
-   return function Injected(props: Omit<TProps, TInjectedKeys>) {
-     return <Component {...props as TProps} {...injector} />
-   }
- }
+) {
+  return function Injected(props: Omit<TProps, TInjectedKeys>) {
+    return <Component {...props as TProps} {...injector} />;
+  };
+}
 ```
 
 ### Using `forwardRef`
@@ -247,9 +262,9 @@ export interface Props {
 
 ```tsx
 function PassThrough(props: { as: ReactType<any> }) {
-   const { as: Component } = props;
+  const { as: Component } = props;
 
-   return <Component />
+  return <Component />;
 }
 ```
 
@@ -260,37 +275,41 @@ function PassThrough(props: { as: ReactType<any> }) {
 Components, and JSX in general, are analogous to functions. When a component can render differently based on their props, it's similar to how a function can be overloaded to have multiple call signatures. In the same way, you can overload a function component's call signature to list all of its different "versions".
 
 A very common use case for this is to render something as either a button or an anchor, based on if it receives a `href` attribute.
+
 ```tsx
-type ButtonProps = JSX.IntrinsicElements['button']
-type AnchorProps = JSX.IntrinsicElements['a']
+type ButtonProps = JSX.IntrinsicElements['button'];
+type AnchorProps = JSX.IntrinsicElements['a'];
 
 // optionally use a custom type guard
-function isPropsForAnchorElement(props: ButtonProps | AnchorProps): props is AnchorProps {
-  return 'href' in props
+function isPropsForAnchorElement(
+  props: ButtonProps | AnchorProps
+): props is AnchorProps {
+  return 'href' in props;
 }
 
-function Clickable(props: ButtonProps): JSX.Element
-function Clickable(props: AnchorProps): JSX.Element
+function Clickable(props: ButtonProps): JSX.Element;
+function Clickable(props: AnchorProps): JSX.Element;
 function Clickable(props: ButtonProps | AnchorProps) {
   if (isPropsForAnchorElement(props)) {
-    return <a {...props} />
+    return <a {...props} />;
   } else {
-    return <button {...props } />
+    return <button {...props} />;
   }
 }
 ```
 
 They don't even need to be completely different props, as long as they have at least one difference in properties:
-```tsx
-type LinkProps = Omit<JSX.IntrinsicElements[ 'a' ], 'href'> & { to?: string }
 
-function RouterLink(props: LinkProps): JSX.Element
-function RouterLink(props: AnchorProps): JSX.Element
+```tsx
+type LinkProps = Omit<JSX.IntrinsicElements['a'], 'href'> & { to?: string };
+
+function RouterLink(props: LinkProps): JSX.Element;
+function RouterLink(props: AnchorProps): JSX.Element;
 function RouterLink(props: LinkProps | AnchorProps) {
   if ('to' in props) {
-    return <a {...props} />
+    return <a {...props} />;
   } else {
-    return <Link {...props } />
+    return <Link {...props} />;
   }
 }
 ```
@@ -306,27 +325,28 @@ type AnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
 type RouterLinkProps = Omit<NavLinkProps, 'href'>
 
 const Link = <T extends {}>(
-    props: LinkProps & T extends RouterLinkProps ? RouterLinkProps : AnchorProps
+props: LinkProps & T extends RouterLinkProps ? RouterLinkProps : AnchorProps
 ) => {
-    if ((props as RouterLinkProps).to) {
-        return <NavLink {...props as RouterLinkProps} />
-    } else {
-        return <a {...props as AnchorProps} />
-    }
+if ((props as RouterLinkProps).to) {
+return <NavLink {...props as RouterLinkProps} />
+} else {
+return <a {...props as AnchorProps} />
+}
 }
 
 <Link<RouterLinkProps> to="/">My link</Link> // ok
 <Link<AnchorProps> href="/">My link</Link> // ok
 <Link<RouterLinkProps> to="/" href="/">My link</Link> // error
-```
-  
+
+````
+
 </details>
 
 
 
 <details>
   <summary><b>Approach: Composition</b></summary>
-  
+
 If you want to conditionally render a component, sometimes is better to use [React's composition model](https://reactjs.org/docs/composition-vs-inheritance.html) to have simpler components and better to understand typings:
 
 ```tsx
@@ -355,28 +375,27 @@ const LinkButton: React.FunctionComponent<RouterLinkProps> = (props) => (
 <LinkButton to="/login">Login</LinkButton>
 <AnchorButton href="/login">Login</AnchorButton>
 <AnchorButton href="/login" to="/test">Login</AnchorButton> // Error: Property 'to' does not exist on type...
-```
+````
+
 </details>
-
-
 
 ## Props: One or the Other but not Both
 
 Use the `in` keyword, function overloading, and union types to make components that take either one or another sets of props, but not both:
 
 ```tsx
-type Props1 = { foo: string }
-type Props2 = { bar: string }
+type Props1 = { foo: string };
+type Props2 = { bar: string };
 
-function MyComponent(props: Props1): JSX.Element
-function MyComponent(props: Props2): JSX.Element
+function MyComponent(props: Props1): JSX.Element;
+function MyComponent(props: Props2): JSX.Element;
 function MyComponent(props: Props1 | Props2) {
   if ('foo' in props) {
     // props.bar // error
-    return <div>{props.foo}</div>
+    return <div>{props.foo}</div>;
   } else {
     // props.foo // error
-    return <div>{props.bar}</div>
+    return <div>{props.bar}</div>;
   }
 }
 const UsageComponent: React.FC = () => (
@@ -385,22 +404,21 @@ const UsageComponent: React.FC = () => (
     <MyComponent bar="bar" />
     {/* <MyComponent foo="foo" bar="bar"/> // invalid */}
   </div>
-)
+);
 ```
-
 
 ## Props: Must Pass Both
 
 ```tsx
-type OneOrAnother<T1, T2> = 
+type OneOrAnother<T1, T2> =
   | (T1 & { [K in keyof T2]?: undefined })
-  | (T2 & { [K in keyof T1]?: undefined })
+  | (T2 & { [K in keyof T1]?: undefined });
 
-type Props = OneOrAnother<{ a: string; b: string }, {}>
+type Props = OneOrAnother<{ a: string; b: string }, {}>;
 
-const a: Props = { a: 'a' } // error
-const b: Props = { b: 'b' } // error
-const ab: Props = { a: 'a', b: 'b' } // ok
+const a: Props = { a: 'a' }; // error
+const b: Props = { b: 'b' }; // error
+const ab: Props = { a: 'a', b: 'b' }; // ok
 ```
 
 Thanks [diegohaz](https://twitter.com/kentcdodds/status/1085655423611367426)
@@ -411,10 +429,10 @@ Sometimes when intersecting types, we want to define our own version of an attri
 
 ```tsx
 export interface Props {
-  label: React.ReactNode // this will conflict with the InputElement's label
+  label: React.ReactNode; // this will conflict with the InputElement's label
 }
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 // usage
 export const Checkbox = (
@@ -422,12 +440,9 @@ export const Checkbox = (
 ) => {
   const { label } = props;
   return (
-    <div className='Checkbox'>
-      <label className='Checkbox-label'>
-        <input
-          type="checkbox"
-          {...props}
-        />
+    <div className="Checkbox">
+      <label className="Checkbox-label">
+        <input type="checkbox" {...props} />
       </label>
       <span>{label}</span>
     </div>
@@ -441,33 +456,44 @@ As you can see from the Omit example above, you can write significant logic in y
 
 ## Extracting Prop Types of a Component
 
-*(Contributed by [@ferdaber](https://github.com/sw-yx/react-typescript-cheatsheet/issues/63))*
+_(Contributed by [@ferdaber](https://github.com/sw-yx/react-typescript-cheatsheet/issues/63))_
 
-There are a lot of places where you want to reuse some slices of props because of prop drilling, 
+There are a lot of places where you want to reuse some slices of props because of prop drilling,
 so you can either export the props type as part of the module or extract them (either way works).
 
 The advantage of extracting the prop types is that you won't need to export everything, and a refactor of the source of truth component will propagate to all consuming components.
 
-
 ```ts
-import { ComponentProps, JSXElementConstructor } from 'react'
+import { ComponentProps, JSXElementConstructor } from 'react';
 
 // goes one step further and resolves with propTypes and defaultProps properties
-type ApparentComponentProps<C> = C extends JSXElementConstructor<infer P> ? JSX.LibraryManagedAttributes<C, P> : ComponentProps<C>
+type ApparentComponentProps<C> = C extends JSXElementConstructor<infer P>
+  ? JSX.LibraryManagedAttributes<C, P>
+  : ComponentProps<C>;
 ```
 
-You can also use them to strongly type custom event handlers if they're not written at the call sites themselves 
+You can also use them to strongly type custom event handlers if they're not written at the call sites themselves
 (i.e. inlined with the JSX attribute):
 
 ```tsx
 // my-inner-component.tsx
-export function MyInnerComponent(props: { onSomeEvent(event: ComplexEventObj, moreArgs: ComplexArgs): SomeWeirdReturnType }) { /* ... */ }
+export function MyInnerComponent(props: {
+  onSomeEvent(
+    event: ComplexEventObj,
+    moreArgs: ComplexArgs
+  ): SomeWeirdReturnType;
+}) {
+  /* ... */
+}
 
 // my-consuming-component.tsx
 export function MyConsumingComponent() {
   // event and moreArgs are contextually typed along with the return value
-  const theHandler: Props<typeof MyInnerComponent>['onSomeEvent'] = (event, moreArgs) => {}
-  return <MyInnerComponent onSomeEvent={theHandler} />
+  const theHandler: Props<typeof MyInnerComponent>['onSomeEvent'] = (
+    event,
+    moreArgs
+  ) => {};
+  return <MyInnerComponent onSomeEvent={theHandler} />;
 }
 ```
 
@@ -475,15 +501,13 @@ export function MyConsumingComponent() {
 
 Sometimes DefinitelyTyped can get it wrong, or isn't quite addressing your use case. You can declare your own file with the same interface name. Typescript will merge interfaces with the same name.
 
-
 # Section 2: Useful Patterns by TypeScript Version
 
 TypeScript Versions often introduce new ways to do things; this section helps current users of React + TypeScript upgrade TypeScript versions and explore patterns commonly used by TypeScript + React apps and libraries. This may have duplications with other sections; if you spot any discrepancies, [file an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new)!
 
-*TypeScript version guides before 2.9 are unwritten, please feel free to send a PR!* Apart from official TS team communication we also recommend [Marius Schulz's blog for version notes](https://mariusschulz.com/).
+_TypeScript version guides before 2.9 are unwritten, please feel free to send a PR!_ Apart from official TS team communication we also recommend [Marius Schulz's blog for version notes](https://mariusschulz.com/).
 
 ## TypeScript 2.9
-
 
 [[Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html) | [Blog Post](https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/)]
 
@@ -491,13 +515,13 @@ TypeScript Versions often introduce new ways to do things; this section helps cu
 
 ```tsx
 export interface InputFormProps {
-    foo: string; // this is understood inside the template string below
+  foo: string; // this is understood inside the template string below
 }
 
-export const InputForm = styledInput<InputFormProps> `
+export const InputForm = styledInput<InputFormProps>`
     color:
-        ${({themeName}) => themeName === 'dark' ? 'black' : 'white'};
-    border-color: ${({foo}) => foo ? 'red' : 'black'};
+        ${({ themeName }) => (themeName === 'dark' ? 'black' : 'white')};
+    border-color: ${({ foo }) => (foo ? 'red' : 'black')};
 `;
 ```
 
@@ -508,7 +532,7 @@ https://github.com/Microsoft/TypeScript/pull/22415
 Helps with typing/using generic components:
 
 ```tsx
-// instead of 
+// instead of
 <Formik render={(props: FormikProps<Values>) => ....}/>
 
 // usage
@@ -527,30 +551,30 @@ More info: https://github.com/basarat/typescript-book/blob/master/docs/jsx/react
 ```ts
 // `rest` accepts any number of strings - even none!
 function foo(...rest: string[]) {
-    // ...
+  // ...
 }
 
-foo("hello"); // works
-foo("hello", "world"); // also works
+foo('hello'); // works
+foo('hello', 'world'); // also works
 ```
 
 2. Support for `propTypes` and `static defaultProps` in JSX using `LibraryManagedAttributes`:
 
 ```ts
 export interface Props {
-    name: string
+  name: string;
 }
 
 export class Greet extends React.Component<Props> {
-    render() {
-        const { name } = this.props;
-        return <div>Hello ${name.toUpperCase()}!</div>;
-    }
-    static defaultProps = { name: "world"}
+  render() {
+    const { name } = this.props;
+    return <div>Hello ${name.toUpperCase()}!</div>;
+  }
+  static defaultProps = { name: 'world' };
 }
 
 // Type-checks! No type assertions needed!
-let el = <Greet />
+let el = <Greet />;
 ```
 
 3. new `Unknown` type
@@ -559,12 +583,12 @@ For typing API's to force type checks - not specifically React related, however 
 
 ```tsx
 interface IComment {
-    date: Date;
-    message: string;
+  date: Date;
+  message: string;
 }
 
 interface IDataService1 {
-    getData(): any;
+  getData(): any;
 }
 
 let service1: IDataService1;
@@ -574,7 +598,7 @@ response.a.b.c.d; // RUNTIME ERROR
 // ----- compare with -------
 
 interface IDataService2 {
-    getData(): unknown; // ooo
+  getData(): unknown; // ooo
 }
 
 let service2: IDataService2;
@@ -582,14 +606,13 @@ const response2 = service2.getData();
 // response2.a.b.c.d; // COMPILE TIME ERROR if you do this
 
 if (typeof response === 'string') {
-    console.log(response.toUpperCase()); // `response` now has type 'string'
+  console.log(response.toUpperCase()); // `response` now has type 'string'
 }
 ```
 
 You can also assert a type, or use a **type guard** against an `unknown` type. This is better than resorting to `any`.
 
 ## TypeScript 3.1
-
 
 [[Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html) | [Blog Post](https://blogs.msdn.microsoft.com/typescript/announcing-typescript-3-1/)]
 
@@ -613,7 +636,6 @@ FooComponent.defaultProps = {
 
 nothing specifically React related.
 
-
 ## TypeScript 3.3
 
 [[Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-3.html) | [Blog Post](https://blogs.msdn.microsoft.com/typescript/2019/01/31/announcing-typescript-3-3/)]
@@ -623,7 +645,6 @@ nothing specifically React related.
 ## TypeScript Roadmap
 
 https://github.com/Microsoft/TypeScript/wiki/Roadmap
-
 
 # Section 3: Misc. Concerns
 
@@ -642,13 +663,12 @@ interface IMyComponentProps {
 export class MyComponent extends React.Component<IMyComponentProps, {}> {
   static propTypes = {
     autoHeight: PropTypes.bool,
-    secondProp: PropTypes.number.isRequired,
+    secondProp: PropTypes.number.isRequired
   };
 }
 ```
 
 [Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
-
 
 ## Commenting Components
 
@@ -692,10 +712,10 @@ You should check out large projects that are migrating from flow to pick up conc
 - [Storybook](https://github.com/storybooks/storybook/issues/5030)
 - [VueJS](https://medium.com/the-vue-point/plans-for-the-next-iteration-of-vue-js-777ffea6fabf)
 
-Useful libraries: 
+Useful libraries:
 
 - https://github.com/bcherny/flow-to-typescript
-- <https://github.com/piotrwitek/utility-types>. 
+- <https://github.com/piotrwitek/utility-types>.
 
 If you have specific advice in this area, please file a PR!
 
@@ -703,7 +723,7 @@ If you have specific advice in this area, please file a PR!
 
 ## Prettier + TSLint
 
-*Contributed by: [@azdanov](https://github.com/sw-yx/react-typescript-cheatsheet/pull/14)*
+_Contributed by: [@azdanov](https://github.com/sw-yx/react-typescript-cheatsheet/pull/14)_
 
 To use prettier with TSLint you will need [`tslint-config-prettier`](https://github.com/alexjoverm/tslint-config-prettier) which disables all the conflicting rules and optionally [`tslint-plugin-prettier`](https://github.com/ikatyang/tslint-plugin-prettier) which will highlight differences as TSLint issues.
 
@@ -782,6 +802,7 @@ npm i -D typescript-eslint-parser
 // And in your ESLint configuration file:
 
 "parser": "typescript-eslint-parser"
+
   </pre>
   </td>
   <td>
@@ -833,7 +854,7 @@ An example github repository with a project showing how to integrate [eslint + t
 
 ## Working with Non-TypeScript Libraries (writing your own index.d.ts)
 
-*Not written yet.*
+_Not written yet._
 
 Please contribute on this topic! [We have an ongoing issue here with some references](https://github.com/sw-yx/react-typescript-cheatsheet/issues/8).
 
@@ -857,7 +878,7 @@ The `@types` typings export both "public" types meant for your use as well as "p
 
 Most Commonly Used Interfaces and Types
 
-- `ReactNode` - anything that is renderable *inside* of JSX, this is NOT the same as what can be rendered by a component!
+- `ReactNode` - anything that is renderable _inside_ of JSX, this is NOT the same as what can be rendered by a component!
 - `Component` - base class of all class-based components
 - `PureComponent` - base class for all class-based optimized components
 - `FC`, `FunctionComponent` - a complete interface for function components, often used to type external components instead of typing your own
@@ -901,10 +922,6 @@ Anything not listed above is considered an internal type and not public. If you'
 
 To be written
 
-
 # My question isn't answered here!
 
 - [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
-
-
-

--- a/HOC.md
+++ b/HOC.md
@@ -66,14 +66,14 @@ const DataSource = {
 };
 /** type aliases just to deduplicate */
 type DataType = typeof DataSource;
-type TODO_ANY = any;
+// type TODO_ANY = any;
 
 /** utility types we use */
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type Optionalize<T extends K, K> = Omit<T, keyof K>;
+// type Optionalize<T extends K, K> = Omit<T, keyof K>;
 
 /** Rewritten Components from the React docs that just uses injected data prop */
-function CommentList({ data }: WithSubscriptionProps) {
+function CommentList({ data }: WithDataProps<typeof comments>) {
   return (
     <div>
       {data.map((comment: CommentType) => (
@@ -82,13 +82,13 @@ function CommentList({ data }: WithSubscriptionProps) {
     </div>
   );
 }
-interface BlogPostProps extends WithSubscriptionProps {
+interface BlogPostProps extends WithDataProps<string> {
   id: number;
   // children: ReactNode;
 }
 function BlogPost({ data, id }: BlogPostProps) {
   return (
-    <div>
+    <div key={id}>
       <TextBlock text={data} />;
     </div>
   );
@@ -100,44 +100,55 @@ function BlogPost({ data, id }: BlogPostProps) {
 Example HOC from React Docs translated to TypeScript
 
 ```tsx
-// // ACTUAL HOC
-interface WithSubscriptionProps {
-  data: TODO_ANY;
+// these are the props to be injected by the HOC
+interface WithDataProps<T> {
+  data: T; // data is generic
 }
-/** This function takes a component... */
-function withSubscription<
-  T extends WithSubscriptionProps = WithSubscriptionProps
->(
-  WrappedComponent: React.ComponentType<T>,
-  selectData: (DataSource: DataType, props: TODO_ANY) => TODO_ANY
+// T is the type of data
+// P is the props of the wrapped component that is inferred
+// C is the actual interface of the wrapped component (used to grab defaultProps from it)
+export function withSubscription<T, P extends WithDataProps<T>, C>(
+  // this type allows us to infer P, but grab the type of WrappedComponent separately without it interfering with the inference of P
+  WrappedComponent: JSXElementConstructor<P> & C,
+  // selectData is a functor for T
+  // props is Readonly because it's readonly inside of the class
+  selectData: (
+    dataSource: typeof DataSource,
+    props: Readonly<JSX.LibraryManagedAttributes<C, Omit<P, 'data'>>>
+  ) => T
 ) {
-  // ...and returns another component...
-  return class extends React.Component<Optionalize<T, WithSubscriptionProps>> {
-    state = {
-      data: selectData(DataSource, this.props)
-    };
-
-    componentDidMount() {
-      // ... that takes care of the subscription...
-      DataSource.addChangeListener(this.handleChange);
+  // the magic is here: JSX.LibraryManagedAttributes will take the type of WrapedComponent and resolve its default props
+  // against the props of WithData, which is just the original P type with 'data' removed from its requirements
+  type Props = JSX.LibraryManagedAttributes<C, Omit<P, 'data'>>;
+  type State = {
+    data: T;
+  };
+  return class WithData extends Component<Props, State> {
+    constructor(props: Props) {
+      super(props);
+      this.handleChange = this.handleChange.bind(this);
+      this.state = {
+        data: selectData(DataSource, props)
+      };
     }
 
-    componentWillUnmount() {
+    componentDidMount = () => DataSource.addChangeListener(this.handleChange);
+
+    componentWillUnmount = () =>
       DataSource.removeChangeListener(this.handleChange);
-    }
 
-    handleChange = () => {
+    handleChange = () =>
       this.setState({
         data: selectData(DataSource, this.props)
       });
-    };
 
     render() {
-      // ... and renders the wrapped component with the fresh data!
-      // Notice that we pass through any additional props
-      return <WrappedComponent data={this.state.data} {...this.props as T} />;
+      // the typing for spreading this.props is... very complex. best way right now is to just type it as any
+      // data will still be typechecked
+      return <WrappedComponent data={this.state.data} {...this.props as any} />;
     }
   };
+  // return WithData;
 }
 
 /** HOC usage with Components */
@@ -148,7 +159,7 @@ export const CommentListWithSubscription = withSubscription(
 
 export const BlogPostWithSubscription = withSubscription(
   BlogPost,
-  (DataSource: DataType, props: React.ComponentProps<typeof BlogPost>) =>
+  (DataSource: DataType, props: Omit<BlogPostProps, 'data'>) =>
     DataSource.getBlogPost(props.id)
 );
 ```

--- a/HOC.md
+++ b/HOC.md
@@ -22,7 +22,7 @@
 
 In this first section we refer closely to [the React docs on HOCs](https://reactjs.org/docs/higher-order-components.html) and offer direct TypeScript parallels.
 
-## Example: Use HOCs For Cross-Cutting Concerns
+## Docs Example: Use HOCs For Cross-Cutting Concerns
 
 <details>
 
@@ -152,3 +152,151 @@ export const BlogPostWithSubscription = withSubscription(
     DataSource.getBlogPost(props.id)
 );
 ```
+
+## Docs Example: Don’t Mutate the Original Component. Use Composition.
+
+This is pretty straightforward - make sure to assert the passed props as `T` [due to the TS 3.2 bug](https://github.com/Microsoft/TypeScript/issues/28938#issuecomment-450636046).
+
+```tsx
+function logProps<T>(WrappedComponent: React.ComponentType<T>) {
+  return class extends React.Component {
+    componentWillReceiveProps(
+      nextProps: React.ComponentProps<typeof WrappedComponent>
+    ) {
+      console.log('Current props: ', this.props);
+      console.log('Next props: ', nextProps);
+    }
+    render() {
+      // Wraps the input component in a container, without mutating it. Good!
+      return <WrappedComponent {...this.props as T} />;
+    }
+  };
+}
+```
+
+## Docs Example: Pass Unrelated Props Through to the Wrapped Component
+
+No TypeScript specific advice needed here.
+
+## Docs Example: Maximizing Composability
+
+HOCs can take the form of Functions that return Higher Order Components that return Components.
+
+`connect` from `react-redux` has a number of overloads you can take inspiration [from in the source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-redux/v5/index.d.ts#L77).
+
+Here we build our own mini `connect` to understand HOCs:
+
+<details>
+
+<summary>
+<b>Misc variables referenced in the example below</b>
+</summary>
+
+```tsx
+/** utility types we use */
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Optionalize<T extends K, K> = Omit<T, keyof K>;
+// // ACTUAL HOC
+interface WithSubscriptionProps {
+  data: TODO_ANY;
+}
+
+/** dummy Data */
+type CommentType = { text: string; id: number };
+const comments: CommentType[] = [
+  {
+    text: 'comment1',
+    id: 1
+  },
+  {
+    text: 'comment2',
+    id: 2
+  }
+];
+/** dummy child components that take anything */
+const Comment = (_: any) => null;
+type TODO_ANY = any;
+/** Rewritten Components from the React docs that just uses injected data prop */
+function CommentList({ data }: WithSubscriptionProps) {
+  return (
+    <div>
+      {data.map((comment: CommentType) => (
+        <Comment comment={comment} key={comment.id} />
+      ))}
+    </div>
+  );
+}
+```
+
+</details>
+
+```tsx
+const commentSelector = (_: any, ownProps: any) => ({
+  id: ownProps.id
+});
+const commentActions = () => ({
+  addComment: (str: string) => comments.push({ text: str, id: comments.length })
+});
+
+const ConnectedComment = connect(
+  commentSelector,
+  commentActions
+)(CommentList);
+
+function connect(mapStateToProps: Function, mapDispatchToProps: Function) {
+  return function<T extends WithSubscriptionProps = WithSubscriptionProps>(
+    WrappedComponent: React.ComponentType<T>
+  ) {
+    // Creating the inner component. The calculated Props type here is the where the magic happens.
+    return class ComponentWithTheme extends React.Component<
+      Optionalize<T, WithSubscriptionProps>
+    > {
+      public render() {
+        // Fetch the props you want inject. This could be done with context instead.
+        const mappedStateProps = mapStateToProps(this.state, this.props);
+        const mappedDispatchProps = mapDispatchToProps(this.state, this.props);
+        // this.props comes afterwards so the can override the default ones.
+        return (
+          <WrappedComponent
+            {...this.props as T}
+            {...mappedStateProps}
+            {...mappedDispatchProps}
+          />
+        );
+      }
+    };
+  };
+}
+```
+
+## Docs Example: Wrap the Display Name for Easy Debugging
+
+This is pretty straightforward as well.
+
+```tsx
+interface WithSubscriptionProps {
+  data: any;
+}
+
+function withSubscription<
+  T extends WithSubscriptionProps = WithSubscriptionProps
+>(WrappedComponent: React.ComponentType<T>) {
+  class WithSubscription extends React.Component {
+    /* ... */
+    public static displayName = `WithSubscription(${getDisplayName(
+      WrappedComponent
+    )})`;
+  }
+  return WithSubscription;
+}
+
+function getDisplayName<T>(WrappedComponent: React.ComponentType<T>) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+```
+
+## Unwritten
+
+- Don’t Use HOCs Inside the render Method
+- Static Methods Must Be Copied Over
+- Refs Aren’t Passed Through

--- a/HOC.md
+++ b/HOC.md
@@ -22,7 +22,7 @@
 
 In this first section we refer closely to [the React docs on HOCs](https://reactjs.org/docs/higher-order-components.html) and offer direct TypeScript parallels.
 
-## Docs Example: Use HOCs For Cross-Cutting Concerns
+## Docs Example: [Use HOCs For Cross-Cutting Concerns](https://reactjs.org/docs/higher-order-components.html#use-hocs-for-cross-cutting-concerns)
 
 <details>
 
@@ -164,7 +164,7 @@ export const BlogPostWithSubscription = withSubscription(
 );
 ```
 
-## Docs Example: Don’t Mutate the Original Component. Use Composition.
+## Docs Example: [Don’t Mutate the Original Component. Use Composition.](https://reactjs.org/docs/higher-order-components.html#dont-mutate-the-original-component-use-composition)
 
 This is pretty straightforward - make sure to assert the passed props as `T` [due to the TS 3.2 bug](https://github.com/Microsoft/TypeScript/issues/28938#issuecomment-450636046).
 
@@ -185,11 +185,11 @@ function logProps<T>(WrappedComponent: React.ComponentType<T>) {
 }
 ```
 
-## Docs Example: Pass Unrelated Props Through to the Wrapped Component
+## Docs Example: [Pass Unrelated Props Through to the Wrapped Component](https://reactjs.org/docs/higher-order-components.html#convention-pass-unrelated-props-through-to-the-wrapped-component)
 
 No TypeScript specific advice needed here.
 
-## Docs Example: Maximizing Composability
+## Docs Example: [Maximizing Composability](https://reactjs.org/docs/higher-order-components.html#convention-maximizing-composability)
 
 HOCs can take the form of Functions that return Higher Order Components that return Components.
 
@@ -277,7 +277,7 @@ function connect(mapStateToProps: Function, mapDispatchToProps: Function) {
 }
 ```
 
-## Docs Example: Wrap the Display Name for Easy Debugging
+## Docs Example: [Wrap the Display Name for Easy Debugging](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)
 
 This is pretty straightforward as well.
 
@@ -303,7 +303,7 @@ function getDisplayName<T>(WrappedComponent: React.ComponentType<T>) {
 }
 ```
 
-## Unwritten
+## Unwritten: [Caveats section](https://reactjs.org/docs/higher-order-components.html#caveats)
 
 - Don’t Use HOCs Inside the render Method
 - Static Methods Must Be Copied Over

--- a/HOC.md
+++ b/HOC.md
@@ -27,7 +27,7 @@ In this first section we refer closely to [the React docs on HOCs](https://react
 <details>
 
 <summary>
-<b>Misc variables reference in the example below</b>
+<b>Misc variables referenced in the example below</b>
 </summary>
 
 ```tsx
@@ -97,6 +97,8 @@ function BlogPost({ data, id }: BlogPostProps) {
 
 </details>
 
+Example HOC from React Docs translated to TypeScript
+
 ```tsx
 // // ACTUAL HOC
 interface WithSubscriptionProps {
@@ -133,7 +135,6 @@ function withSubscription<
     render() {
       // ... and renders the wrapped component with the fresh data!
       // Notice that we pass through any additional props
-      // return <WrappedComponent data={this.state.data} {...this.props} />;
       return <WrappedComponent data={this.state.data} {...this.props as T} />;
     }
   };

--- a/HOC.md
+++ b/HOC.md
@@ -1,0 +1,153 @@
+# HOC Cheatsheet
+
+**This HOC Cheatsheet** compiles all available knowledge for writing Higher Order Components with React and TypeScript.
+
+- We will map closely to [the official docs on HOCs](https://reactjs.org/docs/higher-order-components.html) initially
+- While hooks exist, many libraries and codebases still have a need to type HOCs.
+- Render props may be considered in future
+- The goal is to write HOCs that offer type safety while not getting in the way.
+
+---
+
+### HOC Cheatsheet Table of Contents
+
+<details>
+
+<summary><b>Expand Table of Contents</b></summary>
+
+- [Section 0: Prerequisites](#section-0-prerequisites)
+  </details>
+
+# Section 1: React HOC docs in TypeScript
+
+In this first section we refer closely to [the React docs on HOCs](https://reactjs.org/docs/higher-order-components.html) and offer direct TypeScript parallels.
+
+## Example: Use HOCs For Cross-Cutting Concerns
+
+<details>
+
+<summary>
+<b>Misc variables reference in the example below</b>
+</summary>
+
+```tsx
+/** dummy child components that take anything */
+const Comment = (_: any) => null;
+const TextBlock = Comment;
+
+/** dummy Data */
+type CommentType = { text: string; id: number };
+const comments: CommentType[] = [
+  {
+    text: 'comment1',
+    id: 1
+  },
+  {
+    text: 'comment2',
+    id: 2
+  }
+];
+const blog = 'blogpost';
+
+/** mock data source */
+const DataSource = {
+  addChangeListener(e: Function) {
+    // do something
+  },
+  removeChangeListener(e: Function) {
+    // do something
+  },
+  getComments() {
+    return comments;
+  },
+  getBlogPost(id: number) {
+    return blog;
+  }
+};
+/** type aliases just to deduplicate */
+type DataType = typeof DataSource;
+type TODO_ANY = any;
+
+/** utility types we use */
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Optionalize<T extends K, K> = Omit<T, keyof K>;
+
+/** Rewritten Components from the React docs that just uses injected data prop */
+function CommentList({ data }: WithSubscriptionProps) {
+  return (
+    <div>
+      {data.map((comment: CommentType) => (
+        <Comment comment={comment} key={comment.id} />
+      ))}
+    </div>
+  );
+}
+interface BlogPostProps extends WithSubscriptionProps {
+  id: number;
+  // children: ReactNode;
+}
+function BlogPost({ data, id }: BlogPostProps) {
+  return (
+    <div>
+      <TextBlock text={data} />;
+    </div>
+  );
+}
+```
+
+</details>
+
+```tsx
+// // ACTUAL HOC
+interface WithSubscriptionProps {
+  data: TODO_ANY;
+}
+/** This function takes a component... */
+function withSubscription<
+  T extends WithSubscriptionProps = WithSubscriptionProps
+>(
+  WrappedComponent: React.ComponentType<T>,
+  selectData: (DataSource: DataType, props: TODO_ANY) => TODO_ANY
+) {
+  // ...and returns another component...
+  return class extends React.Component<Optionalize<T, WithSubscriptionProps>> {
+    state = {
+      data: selectData(DataSource, this.props)
+    };
+
+    componentDidMount() {
+      // ... that takes care of the subscription...
+      DataSource.addChangeListener(this.handleChange);
+    }
+
+    componentWillUnmount() {
+      DataSource.removeChangeListener(this.handleChange);
+    }
+
+    handleChange = () => {
+      this.setState({
+        data: selectData(DataSource, this.props)
+      });
+    };
+
+    render() {
+      // ... and renders the wrapped component with the fresh data!
+      // Notice that we pass through any additional props
+      // return <WrappedComponent data={this.state.data} {...this.props} />;
+      return <WrappedComponent data={this.state.data} {...this.props as T} />;
+    }
+  };
+}
+
+/** HOC usage with Components */
+export const CommentListWithSubscription = withSubscription(
+  CommentList,
+  (DataSource: DataType) => DataSource.getComments()
+);
+
+export const BlogPostWithSubscription = withSubscription(
+  BlogPost,
+  (DataSource: DataType, props: React.ComponentProps<typeof BlogPost>) =>
+    DataSource.getBlogPost(props.id)
+);
+```


### PR DESCRIPTION
This is the beginning of a cheatsheet solely focused on teaching how to write HOCs in React and TS. There is a focus on teaching rather than merely showing here.

the first step is to translate the React Docs into TypeScript.

then we address related issues:

- https://github.com/sw-yx/react-typescript-cheatsheet/issues/86
- https://github.com/sw-yx/react-typescript-cheatsheet/issues/78