### PR TITLE
[Basic] Improve the class component defaultProps example

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ export class Greet extends React.Component<Props> {
     const { name } = this.props;
     return <div>Hello ${name.toUpperCase()}!</div>;
   }
-  static defaultProps = { name: 'world' };
+  static defaultProps: Partial<Props> = { name: 'world' };
 }
 
 // Type-checks! No type assertions needed!


### PR DESCRIPTION
**What cheatsheet is this about? (if applicable)**

Basic cheatsheet

--

In the current example, we have a type definition for `Props` but do not make use of it for `defaultProps`. This can lead to a mismatch between the actual fields in `defaultProps` and what the `Props` type defines.

Adding an explicit `Partial<Props>` type to `defaultProps` seems like good example code.
