### PR TITLE
BASIC - Rework Function Components section to prefer normal function …

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Please PR or [File an issue](https://github.com/sw-yx/react-typescript-cheatshee
 These can be written as normal functions that take a props argument and return a JSX element.
 
 ```tsx
-const App = ({ message }: { message: string }) => <div>{message}</div>;
+type AppProps { message: string }; /* could also use interface */
+const App = ({ message }: AppProps) => <div>{message}</div>;
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Please PR or [File an issue](https://github.com/sw-yx/react-typescript-cheatshee
 
 ## Function Components
 
-These can be written as normal functions that take a props argument and return a JSX element.
+These can be written as normal functions that take a `props` argument and return a JSX element.
 
 ```tsx
 type AppProps { message: string }; /* could also use interface */
@@ -166,7 +166,7 @@ const App: React.FC<{ message: string }> = ({ message }) => (
 
 Some differences from the "normal function" version:
 
-- It provides typechecking and autocomplete for static properties like `displayName`, `propTypes`, and `defaultProps` - HOWEVER, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/sw-yx/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
+- It provides typechecking and autocomplete for static properties like `displayName`, `propTypes`, and `defaultProps` - **However**, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/sw-yx/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
 
 - It provides an implicit definition of `children` (see below) - however there are some issues with the implicit `children` type (e.g. [DefinitelyTyped#33006](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33006)), and it might considered better style to be explicit about components that consume `children`, anyway.
 

--- a/README.md
+++ b/README.md
@@ -145,30 +145,29 @@ Please PR or [File an issue](https://github.com/sw-yx/react-typescript-cheatshee
 
 ## Function Components
 
-You can specify the type of props as you use them and rely on type inference:
+These can be written as normal functions that take a props argument and return a JSX element.
 
 ```tsx
 const App = ({ message }: { message: string }) => <div>{message}</div>;
 ```
 
-Or you can use the provided generic type for function components:
+<details>
+
+<summary><b>What about `React.FC`/`React.FunctionComponent`?</b></summary>
+
+You can also write components with `React.FunctionComponent` (or the shorthand `React.FC`):
 
 ```tsx
 const App: React.FC<{ message: string }> = ({ message }) => (
   <div>{message}</div>
-); // React.FunctionComponent also works
+);
 ```
 
-<details>
+Some differences from the "normal function" version:
 
-<summary><b>What's the difference?</b></summary>
+- It provides typechecking and autocomplete for static properties like `displayName`, `propTypes`, and `defaultProps` - HOWEVER, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/sw-yx/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
 
-The former pattern is shorter, so why would people use `React.FunctionComponent` at all?
-
-- If you need to use `children` property inside the function body, in the former case it has to be added explicitly. `FunctionComponent<T>` already includes the correctly typed `children` property which then doesn't have to become part of your type.
-- Typing your function explicitly will also give you typechecking and autocomplete on its static properties, like `displayName`, `propTypes`, and `defaultProps`.
-- _In future_, it will also set `readonly` on your props just like `React.Component<T>` does.
-- HOWEVER, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/sw-yx/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
+- It provides an implicit definition of `children` (see below) - however there are some issues with the implicit `children` type (e.g. [DefinitelyTyped#33006](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33006)), and it might considered better style to be explicit about components that consume `children`, anyway.
 
 ```tsx
 const Title: React.FunctionComponent<{ title: string }> = ({
@@ -177,13 +176,11 @@ const Title: React.FunctionComponent<{ title: string }> = ({
 }) => <div title={title}>{children}</div>;
 ```
 
-If you want to use the `function` keyword instead of an arrow function, you can use this syntax (using a function expression, instead of declaration):
+- _In the future_, it may automatically mark props as `readonly`, though that's a moot point if the props object is destructured in the constructor.
 
-```tsx
-const App: React.FunctionComponent<{ message: string }> = function App({ message }) {
-  return <div>{message}</div>;
-}
-```
+- `React.FunctionComponent` is explicit about the return type, while the normal function version is implict (or else needs additional annotation).
+
+In most cases it makes very little difference which syntax is used, but the `React.FC` syntax is slightly more verbose without providing clear advantage, so precedence was given to the "normal function" syntax.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ const Title: React.FunctionComponent<{ title: string }> = ({
 
 - _In the future_, it may automatically mark props as `readonly`, though that's a moot point if the props object is destructured in the constructor.
 
-- `React.FunctionComponent` is explicit about the return type, while the normal function version is implict (or else needs additional annotation).
+- `React.FunctionComponent` is explicit about the return type, while the normal function version is implicit (or else needs additional annotation).
 
 In most cases it makes very little difference which syntax is used, but the `React.FC` syntax is slightly more verbose without providing clear advantage, so precedence was given to the "normal function" syntax.
 


### PR DESCRIPTION
This is a change, related to some of the discussion in #90 and #87 about `React.FC`/`React.FunctionComponent`.  I realize this change itself is pretty opinionated, as is some of my wording, (though I did attempt to be fair to both sides), but I thought it'd be a good starting point for discussion.

---

There's two syntaxes for declaring function components:

```
// 'normal function' syntax
const C1 = ({message}: {message: string}) => <div>{message}</div>;

const C2: React.FC<{message: string}> => <div>{message}</div>;
```

As currently written, the can either be read as neutral or favoring the `React.FC` syntax: the main section is written neutrally (you can use X or Y) but the sub-points are largely written favoring the `FC` syntax.

This this restructures the section so that the "normal function" syntax is preferred, without strictly recommending against the `React.FC` syntax.  

Most of my arguments for this change are in the new version, but I'll reiterate them here:

* `React.FC` doesn't handle `defaultProps` correctly:

```tsx
const Component: React.FC<message: string> = ({message}) => <div>{message}</div>
Component.defaultProps = {message: "Hello, there"};
const test = <Component />; // Error, message is required.
```

* There may be some issues with the type of the implicit children prop: I listed DefinitelyTyped/DefinitelyTyped#33006 in relation to this point, though perhaps the root cause there is something deeper: that issue ends up linking to some deeper type issues, so maybe those would eventually be resolved.  (So maybe I need to remove that link from my PR)

* Personally, I think explicit children is better than implicit children, anyway.  The props are the contract for a component and if a component expects to have children, that's an important part of the contract.  Also, children can be mandatory with an explicit children prop: 

```tsx
// Errors if used like `<MustHaveChildren />`
const MustHaveChildren = ({children}: {children: React.ReactNode}) => <div>{children}</div>;
```

* Ultimately, there's just not much benefit of `React.FC` to justify the extra characters: I guess it prevents errors like `MyComponent.propType = 'MyComponent'` (should be `propTypes`), and an error like `const MyComponent = () => ({not: 'a valid component'})`.

* Plus, all else being equal, I think it's good for a cheatsheet to have a single clear recommendation, rather than presenting two equivalent options as equal.

---

As a separate commit, I also moved the props into their own type.  Personally I find that's a better template as it quickly becomes unreadable to inline more than a couple props.  (I can split that into its own PR or drop it)